### PR TITLE
WindowsAzure.Storage replaced by Microsoft.Azure.Storage.Blob

### DIFF
--- a/SnowMaker.IntegrationTests/SnowMaker.IntegrationTests.csproj
+++ b/SnowMaker.IntegrationTests/SnowMaker.IntegrationTests.csproj
@@ -5,13 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
     <PackageReference Include="NSubstitute" Version="3.0.1" />
     <PackageReference Include="NUnit" Version="3.8.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SnowMaker/SnowMaker.csproj
+++ b/SnowMaker/SnowMaker.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="9.4.0" />
     <PackageReference Include="Microsoft.DiaSymReader.Native" Version="1.5.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">


### PR DESCRIPTION
As of version 9.4.0, the [WindowsAzure.Storage](https://www.nuget.org/packages/WindowsAzure.Storage/)-library has been split into multiple parts and and therefore the required library [Microsoft.Azure.Storage.Blob](https://www.nuget.org/packages/Microsoft.Azure.Storage.Blob/) is referenced instead.